### PR TITLE
add setting for enable SSL.

### DIFF
--- a/photocolle-sdk/test-app/test-app-Info.plist
+++ b/photocolle-sdk/test-app/test-app-Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
XCode7+iOS9環境だとSSL通信を行うアプリにはこの設定が必要なのでtest-appに追加しました。
