### PR TITLE
detour make release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ copy-framework-source:
 	rm -f $(PACKAGEDIR)/$(PHOTOCOLLEDIR)/test-app/photocolle_sdk_setting.plist
 	rm -f $(PACKAGEDIR)/$(PHOTOCOLLEDIR)/test-app/photocolle_setting.plist
 # copy dummy setting files
-	cp -a $(DOCSDIR)/photocolle_sdk_setting.plist $(PACKAGEDIR)/$(PHOTOCOLLEDIR)/test-app/photocolle_sdk_setting.plist
-	cp -a $(DOCSDIR)/photocolle_setting.plist $(PACKAGEDIR)/$(PHOTOCOLLEDIR)/test-app/photocolle_setting.plist
+#	cp -a $(DOCSDIR)/photocolle_sdk_setting.plist $(PACKAGEDIR)/$(PHOTOCOLLEDIR)/test-app/photocolle_sdk_setting.plist
+#	cp -a $(DOCSDIR)/photocolle_setting.plist $(PACKAGEDIR)/$(PHOTOCOLLEDIR)/test-app/photocolle_setting.plist
 
 copy-doc:
 	echo "Copy headerdocs."
@@ -82,8 +82,8 @@ copy-app:
 	rm -f $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/photocolle_sdk_setting.plist
 	rm -f $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/photocolle_setting.plist
 # copy dummy setting files
-	cp -a $(DOCSDIR)/photocolle_sdk_setting.plist $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/photocolle_sdk_setting.plist
-	cp -a $(DOCSDIR)/photocolle_setting.plist $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/photocolle_setting.plist
+#	cp -a $(DOCSDIR)/photocolle_sdk_setting.plist $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/photocolle_sdk_setting.plist
+#	cp -a $(DOCSDIR)/photocolle_setting.plist $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/photocolle_setting.plist
 # remove and copy framework
 	rm -rf $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/PhotoColleSDK.framework
 	cp -a $(PHOTOCOLLEDIR)/target/photocolle-sdk/PhotoColleSDK.framework $(DISTRIBUTIONDIR)/$(TESTAPPDIR)/test-app/


### PR DESCRIPTION
リリースビルドを成功させるための回避策としてこのPRを出します。
あくまで回避策なので注意してください。

リリースビルド後の状態でtest-appを動かすことなどは一切考えていません。
(test-app下のREADMEでは、photocolle_setting.plistはユーザに配置させるように明言していますが、photocolle_sdk_setting.plistは必要ならばとしか書いてありません。
2つとも無いと動かないならばREADMEから変える必要があります。)

Issue: #6 
