### PR TITLE
Fix code sign

### DIFF
--- a/photocolle-sdk/Makefile
+++ b/photocolle-sdk/Makefile
@@ -20,8 +20,7 @@ doc:
 	zip target/$(SDKNAME)-iOS-$(VERSION)_API_doc.zip -r $(DOCOUTPUTDIR)
 
 framework:
-	(chmod 755 ios-build-framework-script.sh; \
-	xcodebuild -scheme PhotoColleSDK clean build -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6';\
+	(xcodebuild -scheme PhotoColleSDK clean build -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6';\
 	sh sdk-archive.sh)
 
 

--- a/photocolle-sdk/photocolle-sdk.xcodeproj/project.pbxproj
+++ b/photocolle-sdk/photocolle-sdk.xcodeproj/project.pbxproj
@@ -1420,15 +1420,8 @@
 				LastUpgradeCheck = 0460;
 				ORGANIZATIONNAME = "奈良 信介";
 				TargetAttributes = {
-					2224F68517A0ECB9007F5183 = {
-						DevelopmentTeam = 37CX6EDKR2;
-					};
-					B6E8CEFB1771668A00C63602 = {
-						DevelopmentTeam = 37CX6EDKR2;
-					};
 					D505013D1D2A148800997E78 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = 37CX6EDKR2;
 					};
 				};
 			};
@@ -1789,6 +1782,7 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1818,6 +1812,7 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/photocolle-sdk/photocolle-sdk.xcodeproj/project.pbxproj
+++ b/photocolle-sdk/photocolle-sdk.xcodeproj/project.pbxproj
@@ -1420,8 +1420,15 @@
 				LastUpgradeCheck = 0460;
 				ORGANIZATIONNAME = "奈良 信介";
 				TargetAttributes = {
+					2224F68517A0ECB9007F5183 = {
+						DevelopmentTeam = 37CX6EDKR2;
+					};
+					B6E8CEFB1771668A00C63602 = {
+						DevelopmentTeam = 37CX6EDKR2;
+					};
 					D505013D1D2A148800997E78 = {
 						CreatedOnToolsVersion = 7.3;
+						DevelopmentTeam = 37CX6EDKR2;
 					};
 				};
 			};
@@ -1707,6 +1714,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1740,6 +1748,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1824,6 +1833,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1843,6 +1853,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1870,6 +1881,7 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1910,7 +1922,8 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Riza Syah (U5D6EP96JV)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";


### PR DESCRIPTION
I checked convert_todynamic_famework brunch.

In the checking, I found following issues:
1. Redundant operation is in photocolle-sdk/Makefile. This is discussed at [this comment](https://github.com/KiiPlatform/photocolle-iOSSDK/pull/12#discussion_r69502022)
2. `make` command on terminal is failed on my local machine.

To fix issue 1, I executed circle ci build without `chmod` command. The result is [this](https://circleci.com/gh/KiiPlatform/photocolle-iOSSDK/76). Without 'chmod' command  works fine.

To fix issue 2, I changed code sign identity. code sign identity was `riza`. I think this cause build failure on my local mac.
