### PR TITLE
enable SSL.

### DIFF
--- a/test-app/test-app/test-app-Info.plist
+++ b/test-app/test-app/test-app-Info.plist
@@ -35,6 +35,11 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>UIMainStoryboardFile~ipad</key>


### PR DESCRIPTION
SSLのHandshakeが失敗するのはSSLが有効化されていないのが原因でした。

ただ、今入っているPhotoColleSDKフレームワークだとHTTPFetcherを使っているので通信時にエラーログが観測されます。
ただこのエラーは継続可能エラーなのですぐには問題になりません。
追々フレームワークの更新は必要だと思います。
しかしtest-appのソースコード上では特に修正が必要ないのですがXCodeプロジェクトの設定をかなり弄る必要があるようです。
設定が正しくないとアプリ起動時にエラー終了してしまいます。

Issue: #15 
