### PR TITLE
Framework name is renamed to PhotoColleSDK.

### DIFF
--- a/PhotoColleSDK.podspec
+++ b/PhotoColleSDK.podspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 #
 #  Be sure to run `pod spec lint photocolle-iOSSDK.podspec' to ensure this is a
 #  valid spec and to remove all comments including this before submitting the spec.
@@ -15,8 +16,8 @@ Pod::Spec.new do |s|
   #  summary should be tweet-length, and the description more in depth.
   #
 
-  s.name         = "photocolle-iOSSDK"
-  s.version      = "1.2.0"
+  s.name         = "PhotoColleSDK"
+  s.version      = "1.1.1"
   s.summary      = "フォトコレ iOS SDK"
 
   # This description is used to generate tags and improve search results.

--- a/test-app/Podfile
+++ b/test-app/Podfile
@@ -2,5 +2,5 @@ platform :ios, '8.0'
 
 target 'test-app' do
 use_frameworks!
-pod 'photocolle-iOSSDK'
+pod 'PhotoColleSDK'
 end

--- a/test-app/Podfile
+++ b/test-app/Podfile
@@ -2,5 +2,5 @@ platform :ios, '8.0'
 
 target 'test-app' do
 use_frameworks!
-pod 'PhotoColleSDK'
+pod 'PhotoColleSDK', :path => '..'
 end

--- a/test-app/test-app/DCAAccessTokenEditViewController.m
+++ b/test-app/test-app/DCAAccessTokenEditViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAAccessTokenEditViewController.h"
 

--- a/test-app/test-app/DCAAccessTokenListViewController.m
+++ b/test-app/test-app/DCAAccessTokenListViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAAccessTokenListViewController.h"
 

--- a/test-app/test-app/DCAAppDelegate.m
+++ b/test-app/test-app/DCAAppDelegate.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAAppDelegate.h"
 

--- a/test-app/test-app/DCACapacityViewController.m
+++ b/test-app/test-app/DCACapacityViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCACapacityViewController.h"
 

--- a/test-app/test-app/DCAContentInfoListArguments.h
+++ b/test-app/test-app/DCAContentInfoListArguments.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 @protocol DCDateFiltering;
 

--- a/test-app/test-app/DCAContentInfoListProvider.m
+++ b/test-app/test-app/DCAContentInfoListProvider.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAContentInfoListProvider.h"
 

--- a/test-app/test-app/DCAContentListSettingViewController.m
+++ b/test-app/test-app/DCAContentListSettingViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAContentListSettingViewController.h"
 

--- a/test-app/test-app/DCADeletionListArguments.h
+++ b/test-app/test-app/DCADeletionListArguments.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 @interface DCADeletionListArguments : NSObject
 

--- a/test-app/test-app/DCADeletionListProvider.m
+++ b/test-app/test-app/DCADeletionListProvider.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCADeletionListProvider.h"
 

--- a/test-app/test-app/DCADetailedContentInfoListArguments.h
+++ b/test-app/test-app/DCADetailedContentInfoListArguments.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 @protocol DCDateFiltering;
 

--- a/test-app/test-app/DCADetailedContentInfoListProvider.m
+++ b/test-app/test-app/DCADetailedContentInfoListProvider.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCADetailedContentInfoListProvider.h"
 

--- a/test-app/test-app/DCADetailedContentListSettingViewController.m
+++ b/test-app/test-app/DCADetailedContentListSettingViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCADetailedContentListSettingViewController.h"
 

--- a/test-app/test-app/DCAEntryPointSettingViewController.m
+++ b/test-app/test-app/DCAEntryPointSettingViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAEntryPointSettingViewController.h"
 #import "DCAAppDelegate.h"

--- a/test-app/test-app/DCAImageViewController.m
+++ b/test-app/test-app/DCAImageViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAImageViewController.h"
 #import "DCAAppDelegate.h"

--- a/test-app/test-app/DCAListViewController.m
+++ b/test-app/test-app/DCAListViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAListViewController.h"
 #import "DCAAppDelegate.h"

--- a/test-app/test-app/DCASettingViewController.m
+++ b/test-app/test-app/DCASettingViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCASettingViewController.h"
 #import "DCAAppDelegate.h"

--- a/test-app/test-app/DCATagListArguments.h
+++ b/test-app/test-app/DCATagListArguments.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 @interface DCATagListArguments : NSObject
 

--- a/test-app/test-app/DCATagListProvider.m
+++ b/test-app/test-app/DCATagListProvider.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCATagListProvider.h"
 

--- a/test-app/test-app/DCAThumbnailViewController.m
+++ b/test-app/test-app/DCAThumbnailViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAThumbnailViewController.h"
 #import "DCAAppDelegate.h"

--- a/test-app/test-app/DCAUploadDelegate.h
+++ b/test-app/test-app/DCAUploadDelegate.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 @class DCDataID;
 

--- a/test-app/test-app/DCAUploadDelegate.m
+++ b/test-app/test-app/DCAUploadDelegate.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAUploadDelegate.h"
 #import "DCAAppDelegate.h"

--- a/test-app/test-app/DCAViewController.m
+++ b/test-app/test-app/DCAViewController.m
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 #import "DCAViewController.h"
 #import "DCAMiscUtils.h"

--- a/test-app/test-app/DCAuthenticationContext_Private.h
+++ b/test-app/test-app/DCAuthenticationContext_Private.h
@@ -1,4 +1,4 @@
-#import <photocolle_iOSSDK/DCPhotoColleSDK.h>
+#import <PhotoColleSDK/DCPhotoColleSDK.h>
 
 @class DCGTMOAuth2Authentication;
 @protocol DCGTMHTTPFetcherServiceProtocol;


### PR DESCRIPTION
- Framework name is changed to PhotoColleSDK
- podspec file is changed to PhotoColleSDK.podspec
- SDK version is changed to 1.1.1. but tag is not created so this is not used with CocoaPods/Spec now
